### PR TITLE
Convert image to PNG before exposing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.twelvemonkeys.imageio</groupId>
+			<artifactId>imageio-pnm</artifactId>
+			<version>3.9.4</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.github.martapietka</groupId>
 			<artifactId>ppm2pbm</artifactId>
 			<version>1.0-SNAPSHOT</version>

--- a/src/main/java/com/github/martapietka/ppm2pbmSpring/ImageService.java
+++ b/src/main/java/com/github/martapietka/ppm2pbmSpring/ImageService.java
@@ -2,10 +2,11 @@ package com.github.martapietka.ppm2pbmSpring;
 
 import org.springframework.stereotype.Service;
 
+import javax.imageio.ImageIO;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 
 @Service
 public class ImageService {
@@ -18,6 +19,10 @@ public class ImageService {
             throw new FileNotFoundException("File not found: " + imagePath);
         }
 
-        return Files.readAllBytes(imageFile.toPath());
+        var image = ImageIO.read(imageFile);
+        var byteArrayOutputStream = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", byteArrayOutputStream);
+
+        return byteArrayOutputStream.toByteArray();
     }
 }

--- a/src/main/java/com/github/martapietka/ppm2pbmSpring/Ppm2PbmController.java
+++ b/src/main/java/com/github/martapietka/ppm2pbmSpring/Ppm2PbmController.java
@@ -15,14 +15,14 @@ public class Ppm2PbmController {
     @Autowired
     private ImageService imageService;
 
-    @GetMapping(value = "/image/{imageName}", produces = "image/x-portable-graymap")
+    @GetMapping(value = "/image/{imageName}", produces = "image/png")
     public ResponseEntity getImage(@PathVariable(value = "imageName") String imageName) {
 
         try {
             byte[] imageBytes = imageService.getImage(imageName);
 
             return ResponseEntity.ok()
-                    .contentType(MediaType.parseMediaType("image/x-portable-graymap"))
+                    .contentType(MediaType.parseMediaType("image/png"))
                     .body((imageBytes));
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Jeśli chodzi o zwracanie grafiki i ustawianie typu - wszystko zrobiłaś dobrze :) niestety formaty z rodziny PNM choć należą do najprostszych, są jednak dość egzotyczne i... przeglądarki ich nie obsługują :) Java zresztą też nie ;) w związku z tym:

* jako format zwracany ustawiłem dużo bardziej powszechny typ PNG
* użyłem standardowego (tzn. normalnie dostępnego w Javie) narzędzia `ImageIO` do odczytania obrazu i przekształcenia go na format PNG
* jednak żeby ten odczyt był w ogóle możliwy (czyli żeby poprawnie rozpoznać i obsłużyć format PGM), trzeba było dostarczyć odpowiednią implementację `ImageReader`  która potrafi go obsłużyć, a żeby się nie przepracować, skorzystałem z gotowej biblioteki która pozwala na obsługę tego i innych rzadszych formatów: https://github.com/haraldk/TwelveMonkeys

Poeksperymentuj, pytaj w razie wątpliwości, a jeśli wszystko będzie względnie jasne - domerguj sobie te zmiany do gałęzi :slightly_smiling_face: 